### PR TITLE
fix: removes the requiring of knobs to show side panel

### DIFF
--- a/packages/widgetbook/lib/src/knobs/builders/knobs_extension.dart
+++ b/packages/widgetbook/lib/src/knobs/builders/knobs_extension.dart
@@ -22,4 +22,6 @@ extension KnobsExtension on BuildContext {
 
     return KnobsBuilder(register);
   }
+
+  void showSidePanel() => WidgetbookState.of(this).setForceSidePanel();
 }

--- a/packages/widgetbook/lib/src/knobs/builders/knobs_extension.dart
+++ b/packages/widgetbook/lib/src/knobs/builders/knobs_extension.dart
@@ -22,6 +22,4 @@ extension KnobsExtension on BuildContext {
 
     return KnobsBuilder(register);
   }
-
-  void showSidePanel() => WidgetbookState.of(this).setForceSidePanel();
 }

--- a/packages/widgetbook/lib/src/layout/desktop_layout.dart
+++ b/packages/widgetbook/lib/src/layout/desktop_layout.dart
@@ -57,19 +57,22 @@ class DesktopLayout extends StatelessWidget implements BaseLayout {
             child: Builder(
               builder: (context) {
                 final state = WidgetbookState.of(context);
-                final showKnobsPanel = state.canShowPanel(LayoutPanel.knobs) &&
+                
+                final canShowKnobs = state.canShowPanel(LayoutPanel.knobs) &&
                     state.knobs.isNotEmpty;
+
+                final canShowSidePanel = canShowKnobs || showAddonsPanel;
 
                 return Card(
                   child: SettingsPanel(
-                    settings: showKnobsPanel
+                    settings: canShowSidePanel
                         ? [
                             if (state.isNext) ...{
                               SettingsPanelData(
                                 name: 'Args',
                                 builder: argsBuilder,
                               ),
-                            } else ...{
+                            } else if (canShowKnobs) ...{
                               SettingsPanelData(
                                 name: 'Knobs',
                                 builder: knobsBuilder,

--- a/packages/widgetbook/lib/src/layout/desktop_layout.dart
+++ b/packages/widgetbook/lib/src/layout/desktop_layout.dart
@@ -1,12 +1,16 @@
 import 'package:flutter/material.dart';
+import 'package:meta/meta.dart';
 import 'package:resizable_widget/resizable_widget.dart';
 
 import '../settings/settings.dart';
 import '../state/state.dart';
 import '../widgetbook_theme.dart';
 import 'base_layout.dart';
-import 'examples_panel_data.dart';
 
+/// The [DesktopLayout] is a layout for desktop devices that allows
+/// displaying the navigation, addons, knobs, and workbench in a
+/// resizable layout.
+@internal
 class DesktopLayout extends StatelessWidget implements BaseLayout {
   const DesktopLayout({
     super.key,
@@ -31,12 +35,12 @@ class DesktopLayout extends StatelessWidget implements BaseLayout {
     const kWorkbenchPercentage = 1 - 2 * kSidePanelPercentage;
 
     final showNavigationPanel = state.canShowPanel(LayoutPanel.navigation);
-    final showAddonsPanel = state.canShowPanel(LayoutPanel.addons) &&
-        state.addons != null &&
-        state.addons!.isNotEmpty;
+    final showSettingsPanel =
+        state.canShowPanel(LayoutPanel.addons) ||
+        state.canShowPanel(LayoutPanel.knobs);
 
     return ColoredBox(
-      key: ValueKey(state.isNext),
+      key: ValueKey(state.isNext), // Rebuild when switching to next
       color: WidgetbookTheme.of(context).colorScheme.surface,
       child: ResizableLayout(
         items: [
@@ -44,7 +48,6 @@ class DesktopLayout extends StatelessWidget implements BaseLayout {
             ResizableLayoutItem(
               percentage: kSidePanelPercentage,
               child: Card(
-                key: ValueKey(state.isNext),
                 child: navigationBuilder(context),
               ),
             ),
@@ -52,61 +55,43 @@ class DesktopLayout extends StatelessWidget implements BaseLayout {
             percentage: kWorkbenchPercentage,
             child: workbench,
           ),
-          ResizableLayoutItem(
-            percentage: kSidePanelPercentage,
-            child: Builder(
-              builder: (context) {
-                final state = WidgetbookState.of(context);
-                
-                final canShowKnobs = state.canShowPanel(LayoutPanel.knobs) &&
-                    state.knobs.isNotEmpty;
-
-                final canShowSidePanel = canShowKnobs || showAddonsPanel;
-
-                return Card(
-                  child: SettingsPanel(
-                    settings: canShowSidePanel
-                        ? [
-                            if (state.isNext) ...{
-                              SettingsPanelData(
-                                name: 'Args',
-                                builder: argsBuilder,
-                              ),
-                            } else if (canShowKnobs) ...{
-                              SettingsPanelData(
-                                name: 'Knobs',
-                                builder: knobsBuilder,
-                              ),
-                            },
-                            if (showAddonsPanel) ...{
-                              SettingsPanelData(
-                                name: 'Addons',
-                                builder: addonsBuilder,
-                              ),
-                            },
-                          ]
-                        : [
-                            SettingsPanelData(
-                              name: 'Utils',
-                              builder: (context) => [
-                                ExamplesPanelData(
-                                  designLink: state.useCase?.designLink,
-                                  documentationLink: state.useCase?.docsLink,
-                                ),
-                              ],
-                            ),
-                          ],
-                  ),
-                );
-              },
+          if (showSettingsPanel)
+            ResizableLayoutItem(
+              percentage: kSidePanelPercentage,
+              child: Card(
+                child: SettingsPanel(
+                  settings: [
+                    if (state.canShowPanel(LayoutPanel.knobs)) ...{
+                      if (state.isNext) ...{
+                        SettingsPanelData(
+                          name: 'Args',
+                          builder: argsBuilder,
+                        ),
+                      } else ...{
+                        SettingsPanelData(
+                          name: 'Knobs',
+                          builder: knobsBuilder,
+                        ),
+                      },
+                    },
+                    if (state.canShowPanel(LayoutPanel.addons) &&
+                        state.addons != null) ...{
+                      SettingsPanelData(
+                        name: 'Addons',
+                        builder: addonsBuilder,
+                      ),
+                    },
+                  ],
+                ),
+              ),
             ),
-          ),
         ],
       ),
     );
   }
 }
 
+@internal
 class ResizableLayoutItem {
   const ResizableLayoutItem({
     required this.percentage,
@@ -120,6 +105,7 @@ class ResizableLayoutItem {
 /// An improved API for [ResizableWidget] that allows passing both percentage
 /// and child in a single object, allowing to easily add or remove items.
 /// Also distributes the remaining space equally among all items.
+@internal
 class ResizableLayout extends StatelessWidget {
   const ResizableLayout({super.key, required this.items});
 

--- a/packages/widgetbook/lib/src/layout/force_addon_panel.dart
+++ b/packages/widgetbook/lib/src/layout/force_addon_panel.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/widgets.dart';
+
+import '../../widgetbook.dart';
+
+class ForceAddonPanel extends StatefulWidget {
+  const ForceAddonPanel({
+    super.key,
+    required this.child,
+    required this.state,
+  });
+
+  final Widget child;
+  final WidgetbookState state;
+
+  @override
+  State<ForceAddonPanel> createState() => _ForceAddonPanelState();
+}
+
+class _ForceAddonPanelState extends State<ForceAddonPanel> {
+  @override
+  void initState() {
+    super.initState();
+    widget.state.forceSidePanel = true;
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+    widget.state.forceSidePanel = false;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return widget.child;
+  }
+}

--- a/packages/widgetbook/lib/src/layout/force_addon_panel.dart
+++ b/packages/widgetbook/lib/src/layout/force_addon_panel.dart
@@ -17,19 +17,25 @@ class ForceAddonPanel extends StatefulWidget {
 }
 
 class _ForceAddonPanelState extends State<ForceAddonPanel> {
+  String? _pagePath;
+
   @override
   void initState() {
     super.initState();
     widget.state.forceSidePanel = true;
+    _pagePath = widget.state.uri.queryParameters['path'];
   }
 
   @override
   void dispose() {
+    final pagePath = _pagePath;
+    if (pagePath != null && pagePath != widget.state.uri.queryParameters['path']) {
+      widget.state.forceSidePanel = false;
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        widget.state.notifyListeners();
+      });
+    }
     super.dispose();
-    widget.state.forceSidePanel = false;
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      widget.state.notifyListeners();
-    });
   }
 
   @override

--- a/packages/widgetbook/lib/src/layout/force_addon_panel.dart
+++ b/packages/widgetbook/lib/src/layout/force_addon_panel.dart
@@ -27,6 +27,9 @@ class _ForceAddonPanelState extends State<ForceAddonPanel> {
   void dispose() {
     super.dispose();
     widget.state.forceSidePanel = false;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      widget.state.notifyListeners();
+    });
   }
 
   @override

--- a/packages/widgetbook/lib/src/state/widgetbook_state.dart
+++ b/packages/widgetbook/lib/src/state/widgetbook_state.dart
@@ -133,11 +133,6 @@ class WidgetbookState extends ChangeNotifier {
     );
   }
 
-  void setForceSidePanel() {
-    forceSidePanel = true;
-    notifyListeners();
-  }
-
   bool canShowPanel(LayoutPanel panel) {
     if (previewMode) return false;
     if (panels == null) return true;

--- a/packages/widgetbook/lib/src/state/widgetbook_state.dart
+++ b/packages/widgetbook/lib/src/state/widgetbook_state.dart
@@ -68,6 +68,7 @@ class WidgetbookState extends ChangeNotifier {
   final List<WidgetbookIntegration>? integrations;
   final WidgetbookRoot root;
   final Widget home;
+  bool forceSidePanel = false;
 
   /// An optional widget to display at the top of the navigation panel.
   /// This can be used for branding or additional information.
@@ -130,6 +131,11 @@ class WidgetbookState extends ChangeNotifier {
     integrations?.forEach(
       (integration) => integration.onChange(this),
     );
+  }
+
+  void setForceSidePanel() {
+    forceSidePanel = true;
+    notifyListeners();
   }
 
   bool canShowPanel(LayoutPanel panel) {

--- a/packages/widgetbook/lib/widgetbook.dart
+++ b/packages/widgetbook/lib/widgetbook.dart
@@ -17,6 +17,7 @@ export 'src/knobs/knobs.dart'
         IntSliderKnob,
         ListKnob,
         StringKnob;
+export 'src/layout/force_addon_panel.dart';
 export 'src/navigation/nodes/nodes.dart';
 export 'src/state/state.dart';
 export 'src/widgetbook.dart';


### PR DESCRIPTION
### Why
The toolkit needs to display the addons side panel to show the device frame, but it only appears when a knob is registered, this PR fixes the condition to ensure the side panel is shown.