### PR TITLE
Fix: broken widgetbook generator

### DIFF
--- a/packages/widgetbook_generator/lib/src/generators/app_generator.dart
+++ b/packages/widgetbook_generator/lib/src/generators/app_generator.dart
@@ -28,8 +28,10 @@ class AppGenerator extends GeneratorForAnnotation<App> {
   ) async {
     // The directory containing the `widgetbook.dart` file
     // without the leading `/`
-    final inputPath = element.librarySource!.fullName;
-    final inputDir = path.dirname(inputPath).substring(1);
+    final inputPath = element.library?.uri.toString() ?? '';
+    final inputDir = inputPath.startsWith('package:') 
+        ? 'packages/${inputPath.split('/')[1]}' 
+        : path.dirname(inputPath).substring(1);
 
     final emitter = DartEmitter(
       allocator: ResolverAllocator(inputDir),

--- a/packages/widgetbook_generator/lib/src/generators/builder_generator.dart
+++ b/packages/widgetbook_generator/lib/src/generators/builder_generator.dart
@@ -1,3 +1,4 @@
+import 'package:analyzer/dart/analysis/results.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:build/build.dart';
 import 'package:source_gen/source_gen.dart';
@@ -5,18 +6,16 @@ import 'package:widgetbook_annotation/widgetbook_annotation.dart';
 
 class BuilderGenerator extends Generator {
   @override
-  Future<String> generate(
-    LibraryReader library,
-    BuildStep buildStep,
-  ) async {
+  Future<String> generate(LibraryReader library, BuildStep buildStep) async {
     final buffer = StringBuffer();
-    final useCases = <FunctionElement>[];
+    final useCases = <ExecutableElement>[];
 
     // Collect all use cases in the library
-    for (final element
-        in library.annotatedWith(const TypeChecker.fromRuntime(UseCase))) {
-      if (element.element is FunctionElement) {
-        final function = element.element as FunctionElement;
+    for (final element in library.annotatedWith(
+      const TypeChecker.fromRuntime(UseCase),
+    )) {
+      if (element.element is ExecutableElement) {
+        final function = element.element as ExecutableElement;
         if (!function.isPrivate) {
           useCases.add(function);
         }
@@ -26,19 +25,24 @@ class BuilderGenerator extends Generator {
     if (useCases.isEmpty) return '';
 
     // Add part directive
-    final sourceFile = library.element.source.uri.pathSegments.last;
+    final sourceFile = library.element.library.uri.pathSegments.last;
     buffer.writeln("part of '$sourceFile';\n");
 
     // Process each use case
     for (final element in useCases) {
-      final source = element.source;
+      final LibraryFragment fragment = element.library.fragments.first;
+      final source = fragment.source;
       final sourceCode = source.contents.data;
-      final annotationOffset = element.nameOffset;
-      final annotationLength = element.nameLength;
+      final annotationOffset = fragment.nameOffset;
+      final annotationLength = fragment.name?.length;
+
+      if (annotationOffset == null || annotationLength == null) continue;
 
       // Find the start of the function body
-      final bodyStart =
-          sourceCode.indexOf('{', annotationOffset + annotationLength);
+      final bodyStart = sourceCode.indexOf(
+        '{',
+        (annotationOffset + annotationLength),
+      );
       if (bodyStart == -1) continue;
 
       // Find the end of the function body by matching braces
@@ -66,8 +70,9 @@ class BuilderGenerator extends Generator {
         final componentInfo = match.group(0);
         if (componentInfo != null) {
           // Extract the component prop from the ComponentInfo
-          final componentMatch =
-              RegExp(r'component:\s*([^,)]+\))').firstMatch(componentInfo);
+          final componentMatch = RegExp(
+            r'component:\s*([^,)]+\))',
+          ).firstMatch(componentInfo);
           if (componentMatch != null) {
             final componentCode = componentMatch.group(1)?.trim();
             if (componentCode != null) {
@@ -77,7 +82,8 @@ class BuilderGenerator extends Generator {
                 '), codeSnippet: """\n$componentCode\n"""',
               );
               // Replace only the current match
-              builderCode = builderCode.substring(0, match.start) +
+              builderCode =
+                  builderCode.substring(0, match.start) +
                   newComponentInfo +
                   builderCode.substring(match.end);
             }

--- a/packages/widgetbook_generator/lib/src/generators/builder_generator.dart
+++ b/packages/widgetbook_generator/lib/src/generators/builder_generator.dart
@@ -1,4 +1,3 @@
-import 'package:analyzer/dart/analysis/results.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:build/build.dart';
 import 'package:source_gen/source_gen.dart';
@@ -30,7 +29,7 @@ class BuilderGenerator extends Generator {
 
     // Process each use case
     for (final element in useCases) {
-      final LibraryFragment fragment = element.library.fragments.first;
+      final fragment = element.library.fragments.first;
       final source = fragment.source;
       final sourceCode = source.contents.data;
       final annotationOffset = fragment.nameOffset;

--- a/packages/widgetbook_generator/lib/src/generators/use_case_generator.dart
+++ b/packages/widgetbook_generator/lib/src/generators/use_case_generator.dart
@@ -97,8 +97,12 @@ class UseCaseGenerator extends GeneratorForAnnotation<UseCase> {
   /// Resolves the URI of an [element] by retrieving the URI from
   /// the [element]'s source.
   String resolveElementUri(Element element) {
-    final source = element.librarySource ?? element.source!;
-    return source.uri.toString();
+    if (element is LibraryElement) {
+      return element.uri.toString();
+    }
+
+    return element.library?.uri.toString() ??
+        (throw StateError('Cannot resolve URI for element ${element.name}'));
   }
 
   KnobsConfigs _parseKnobsConfigs(

--- a/packages/widgetbook_generator/lib/src/next/arg_builder.dart
+++ b/packages/widgetbook_generator/lib/src/next/arg_builder.dart
@@ -6,13 +6,15 @@ import 'extensions.dart';
 class ArgBuilder {
   ArgBuilder(this.param);
 
-  final ParameterElement param;
+  final FormalParameterElement param;
+
+  String get name => param.name ?? '';
 
   Field buildField() {
     return Field(
       (b) => b
         ..modifier = FieldModifier.final$
-        ..name = param.name
+        ..name = name
         ..type = TypeReference(
           (b) => b
             ..symbol = 'Arg'
@@ -26,7 +28,7 @@ class ArgBuilder {
     return Parameter(
       (b) => b
         ..named = true
-        ..name = param.name
+        ..name = name
         ..type = TypeReference(
           (b) => b
             ..symbol = 'Arg'
@@ -60,7 +62,7 @@ class ArgBuilder {
     return Parameter(
       (b) => b
         ..named = true
-        ..name = param.name
+        ..name = name
         ..type = TypeReference(
           (b) => b
             ..symbol = param.type.nonNullableName

--- a/packages/widgetbook_generator/lib/src/next/args_class_builder.dart
+++ b/packages/widgetbook_generator/lib/src/next/args_class_builder.dart
@@ -11,8 +11,12 @@ class ArgsClassBuilder {
   final DartType widgetType;
   final DartType argsType;
 
-  Iterable<ParameterElement> get params {
-    return (argsType.element as ClassElement).constructors.first.parameters;
+  Iterable<FormalParameterElement> get params {
+    return (argsType.element as ClassElement)
+        .constructors
+        .first
+        .formalParameters
+        .where((param) => param.name != null);
   }
 
   Class build() {
@@ -42,14 +46,14 @@ class ArgsClassBuilder {
               ..initializers.addAll(
                 params.map(
                   (param) => refer('this')
-                      .property(param.name)
+                      .property(param.name!)
                       .assign(
-                        refer(param.name)
+                        refer(param.name!)
                             .maybeProperty(
                           'init',
                           nullSafe: param.type.isNullable,
                         )
-                            .call([], {'name': literalString(param.name)}),
+                            .call([], {'name': literalString(param.name!)}),
                       )
                       .code,
                 ),
@@ -66,21 +70,21 @@ class ArgsClassBuilder {
               ..initializers.addAll(
                 params.map(
                   (param) => refer('this')
-                      .property(param.name)
+                      .property(param.name!)
                       .assign(
                         param.type.isNullable
-                            ? refer(param.name)
+                            ? refer(param.name!)
                                 .equalTo(literalNull)
                                 .conditional(
                                   literalNull,
                                   InvokeExpression.newOf(
                                     refer('Arg.fixed'),
-                                    [refer(param.name)],
+                                    [refer(param.name!)],
                                   ),
                                 )
                             : InvokeExpression.newOf(
                                 refer('Arg.fixed'),
-                                [refer(param.name)],
+                                [refer(param.name!)],
                               ),
                       )
                       .code,
@@ -108,7 +112,7 @@ class ArgsClassBuilder {
               ..lambda = true
               ..body = literalList(
                 params.map(
-                  (param) => refer(param.name),
+                  (param) => refer(param.name!),
                 ),
               ).code,
           ),

--- a/packages/widgetbook_generator/lib/src/next/component_builder.dart
+++ b/packages/widgetbook_generator/lib/src/next/component_builder.dart
@@ -8,8 +8,8 @@ class ComponentBuilder {
   ComponentBuilder(
     this.widgetType,
     this.argsType,
-    this.stories,
-  );
+    List<TopLevelVariableElement> stories,
+  ) : stories = stories.where((story) => story.name != null).toList();
 
   final DartType widgetType;
   final DartType argsType;
@@ -31,10 +31,10 @@ class ComponentBuilder {
             {
               'meta': refer('meta'),
               if (stories.length == 1)
-                'story': refer(stories.first.name)
+                'story': refer(stories.first.name!)
               else
                 'stories': literalList(
-                  stories.map((story) => refer(story.name)).toList(),
+                  stories.map((story) => refer(story.name!)).toList(),
                 ),
             },
           ),

--- a/packages/widgetbook_generator/lib/src/next/components_builder.dart
+++ b/packages/widgetbook_generator/lib/src/next/components_builder.dart
@@ -35,7 +35,8 @@ class ComponentsBuilder implements Builder {
         .map(
           (library) => library.allElements
               .whereType<TopLevelVariableElement>()
-              .firstWhere((element) => element.name.endsWith('Component')),
+              .firstWhere(
+                  (element) => element.name?.endsWith('Component') ?? false),
         )
         .toList();
 
@@ -44,8 +45,8 @@ class ComponentsBuilder implements Builder {
       components
           .map(
             (e) => refer(
-              e.name,
-              e.librarySource?.uri.toString().replaceAll('.book.dart', '.dart'),
+              e.name ?? '',
+              e.library.uri.toString().replaceAll('.book.dart', '.dart'),
             ),
           )
           .toList(),

--- a/packages/widgetbook_generator/lib/src/next/extensions.dart
+++ b/packages/widgetbook_generator/lib/src/next/extensions.dart
@@ -12,7 +12,7 @@ extension ExpressionX on Expression {
   }
 }
 
-extension ParameterElementX on ParameterElement {
+extension ParameterElementX on FormalParameterElement {
   bool get requiresArg {
     return !type.isPrimitive && !type.isNullable && !hasDefaultValue;
   }
@@ -93,7 +93,7 @@ extension DartTypeX on DartType {
         ? TypeMeta(
             'EnumArg<$nonNullableName>',
             refer(nonNullableName).property(
-              (element as EnumElement).fields.first.name,
+              (element as EnumElement).fields.first.name ?? '',
             ),
           )
         : typesMeta[nonNullableName]!;

--- a/packages/widgetbook_generator/lib/src/next/story_class_builder.dart
+++ b/packages/widgetbook_generator/lib/src/next/story_class_builder.dart
@@ -14,8 +14,12 @@ class StoryClassBuilder {
   final DartType widgetType;
   final DartType argsType;
 
-  Iterable<ParameterElement> get params {
-    return (argsType.element as ClassElement).constructors.first.parameters;
+  Iterable<FormalParameterElement> get params {
+    return (argsType.element as ClassElement)
+        .constructors
+        .first
+        .formalParameters
+        .where((param) => param.name != null);
   }
 
   Class build() {
@@ -96,7 +100,7 @@ class StoryClassBuilder {
                         ])
                         ..body = instantiate(
                           (param) => refer('args') //
-                              .property(param.name)
+                              .property(param.name!)
                               .maybeProperty(
                                 'resolve',
                                 nullSafe: param.type.isNullable,
@@ -122,7 +126,7 @@ class StoryClassBuilder {
   }
 
   InvokeExpression instantiate(
-    Expression Function(ParameterElement) assigner,
+    Expression Function(FormalParameterElement) assigner,
   ) {
     return InvokeExpression.newOf(
       refer(widgetType.nonNullableName),
@@ -132,10 +136,10 @@ class StoryClassBuilder {
           .toList(),
       params //
           .where((param) => param.isNamed)
-          .lastBy((param) => param.name)
+          .lastBy((param) => param.name!)
           .map(
             (_, param) => MapEntry(
-              param.name,
+              param.name!,
               assigner(param),
             ),
           ),

--- a/packages/widgetbook_generator/lib/src/next/story_generator.dart
+++ b/packages/widgetbook_generator/lib/src/next/story_generator.dart
@@ -17,7 +17,7 @@ class StoryGenerator extends Generator {
   ) async {
     final storiesVariables = library.allElements
         .whereType<TopLevelVariableElement>()
-        .where((element) => element.name.startsWith('\$'))
+        .where((element) => element.name?.startsWith('\$') ?? false)
         .toList();
 
     final metaVariable = library.allElements

--- a/packages/widgetbook_generator/pubspec.yaml
+++ b/packages/widgetbook_generator/pubspec.yaml
@@ -13,21 +13,21 @@ screenshots:
     path: assets/logo.png
 
 environment:
-  sdk: ">=3.3.0 <4.0.0"
+  sdk: ">=3.8.0 <4.0.0"
 
 dependencies:
-  analyzer: ">=6.5.0 <8.0.0"
+  analyzer: 8.2.0
   build: 3.1.0
   code_builder: ^4.5.0
   collection: ^1.15.0
   crypto: ^3.0.0
   glob: ^2.0.2
-  meta: ^1.7.0
+  meta: 1.17.0
   path: ^1.8.0
-  source_gen: 3.0.0
+  source_gen: 3.1.0
   widgetbook_annotation:
     path: ../../packages/widgetbook_annotation
 
 dev_dependencies:
-  dart_style: 3.0.0
+  dart_style: 3.1.2
   test: ^1.21.0

--- a/packages/widgetbook_generator/test/helpers/code.dart
+++ b/packages/widgetbook_generator/test/helpers/code.dart
@@ -4,7 +4,9 @@ import 'package:test/test.dart';
 
 /// Formats output with dart formatter.
 void useDartFormatter() {
-  final _formatter = DartFormatter();
+  final _formatter = DartFormatter(
+    languageVersion: DartFormatter.latestLanguageVersion,
+  );
 
   EqualsDart.format = (source) {
     try {
@@ -22,8 +24,5 @@ Code wrapInStatement(Expression expression) {
 
 void expectExpression(Expression actual, String expected) {
   useDartFormatter();
-  expect(
-    wrapInStatement(actual),
-    equalsDart('final test = $expected;'),
-  );
+  expect(wrapInStatement(actual), equalsDart('final test = $expected;'));
 }

--- a/packages/widgetbook_test/test/main_test.dart
+++ b/packages/widgetbook_test/test/main_test.dart
@@ -1,8 +1,0 @@
-import 'package:test/test.dart';
-
-void main() {
-  test('placeholder', () {
-    const pass = true;
-    expect(pass, equals(true));
-  });
-}


### PR DESCRIPTION
### Why
The widgetbook haz breaking changes after updating the analyzer version to `8.2.0`, so we need to fix that.

### What is changing
- Update the analyzer in widgetbook_generator and the other libs that breaks because of it.
- Fix all breaking changes

### How to test
1. Clone the repo and go to this branch
2. An easy way to test is change the `pubspec.yaml` of `mobile_ui` and `mobile_toolkit` to import the local widgetbook after get this branch and try to add an `Usecase` like `t_button_all_examples.dart` to the `mobile_ui` widgetbook
3. After adding the example, run build_runner and it should be added to the widgetbook app.